### PR TITLE
fix(pie): use built-in string regex instead of label

### DIFF
--- a/packages/mermaid-parser/src/language-server/pie.langium
+++ b/packages/mermaid-parser/src/language-server/pie.langium
@@ -3,12 +3,10 @@ import './common';
 
 entry PieChart:
     'pie' (showData?='showData')? NEWLINE*
-    ('title' title=Label)? NEWLINE+
+    ('title' title=STRING)? NEWLINE+
     sections+=Section*
 ;
 
 Section:
-    label=Label ':' value=NUMBER NEWLINE+
+    label=STRING ':' value=NUMBER NEWLINE+
 ;
-
-terminal Label: STRING;


### PR DESCRIPTION
by using it, it won't wrap strings with double quotes again in AST