### PR TITLE
fix(parser): fix eof exception for pie charts

### DIFF
--- a/packages/mermaid-parser/src/language-server/common.langium
+++ b/packages/mermaid-parser/src/language-server/common.langium
@@ -1,7 +1,7 @@
 /* terminals */
-terminal NEWLINE: /\r?\n/;
+terminal NEWLINE: /\n/;
 terminal NUMBER returns number: /[0-9]+(\.[0-9]+)?/;
 terminal STRING: /"[^"]*"/;
 
 hidden terminal COMMENT: /%%(?!{(.|\r?\n)*}%%).*/;
-hidden terminal WhiteSpaces: /[ \t]+/;
+hidden terminal WHITESPACE: /[ \r\t]+/;

--- a/packages/mermaid-parser/src/language-server/pie.langium
+++ b/packages/mermaid-parser/src/language-server/pie.langium
@@ -1,12 +1,13 @@
 grammar PieChart
-import './common';
+import "./common";
 
 entry PieChart:
-    'pie' (showData?='showData')? NEWLINE*
-    ('title' title=STRING)? NEWLINE+
-    sections+=Section*
+    "pie" (showData?="showData")? NEWLINE*
+    ("title" title=STRING)?
+    (NEWLINE+ sections+=Section (NEWLINE+ sections+=Section)*)?
+    NEWLINE*
 ;
 
 Section:
-    label=STRING ':' value=NUMBER NEWLINE+
+    label=STRING ":" value=NUMBER
 ;


### PR DESCRIPTION
* convert newline to `\n` and remove \r in whitespace terminal
* wrap string in double quote instead of single quote
* set newline after title as optional
* set newline after section as optional
* set newline everything as optional