### PR TITLE
fix(common): update `NUMBER` and `NEWLINE` terminal rules

### DIFF
--- a/packages/mermaid-parser/src/language/generated/grammar.ts
+++ b/packages/mermaid-parser/src/language/generated/grammar.ts
@@ -39,7 +39,7 @@ export const MermaidGrammar = (): Grammar => loadedMermaidGrammar ?? (loadedMerm
           {
             "$type": "RuleCall",
             "rule": {
-              "$ref": "#/rules@10"
+              "$ref": "#/rules@11"
             },
             "arguments": [],
             "cardinality": "*"
@@ -61,7 +61,7 @@ export const MermaidGrammar = (): Grammar => loadedMermaidGrammar ?? (loadedMerm
           {
             "$type": "RuleCall",
             "rule": {
-              "$ref": "#/rules@10"
+              "$ref": "#/rules@11"
             },
             "arguments": [],
             "cardinality": "*"
@@ -83,7 +83,7 @@ export const MermaidGrammar = (): Grammar => loadedMermaidGrammar ?? (loadedMerm
                   {
                     "$type": "RuleCall",
                     "rule": {
-                      "$ref": "#/rules@10"
+                      "$ref": "#/rules@11"
                     },
                     "arguments": [],
                     "cardinality": "+"
@@ -106,7 +106,7 @@ export const MermaidGrammar = (): Grammar => loadedMermaidGrammar ?? (loadedMerm
               {
                 "$type": "RuleCall",
                 "rule": {
-                  "$ref": "#/rules@10"
+                  "$ref": "#/rules@11"
                 },
                 "arguments": [],
                 "cardinality": "*"
@@ -151,7 +151,7 @@ export const MermaidGrammar = (): Grammar => loadedMermaidGrammar ?? (loadedMerm
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$ref": "#/rules@11"
+                "$ref": "#/rules@13"
               },
               "arguments": []
             }
@@ -170,52 +170,75 @@ export const MermaidGrammar = (): Grammar => loadedMermaidGrammar ?? (loadedMerm
       "name": "TITLE_AND_ACCESSIBILITIES",
       "fragment": true,
       "definition": {
-        "$type": "Alternatives",
+        "$type": "Group",
         "elements": [
           {
-            "$type": "Assignment",
-            "feature": "accDescr",
-            "operator": "=",
-            "terminal": {
-              "$type": "RuleCall",
-              "rule": {
-                "$ref": "#/rules@7"
+            "$type": "Alternatives",
+            "elements": [
+              {
+                "$type": "Assignment",
+                "feature": "accDescr",
+                "operator": "=",
+                "terminal": {
+                  "$type": "RuleCall",
+                  "rule": {
+                    "$ref": "#/rules@8"
+                  },
+                  "arguments": []
+                }
               },
-              "arguments": []
-            }
+              {
+                "$type": "Assignment",
+                "feature": "accTitle",
+                "operator": "=",
+                "terminal": {
+                  "$type": "RuleCall",
+                  "rule": {
+                    "$ref": "#/rules@9"
+                  },
+                  "arguments": []
+                }
+              },
+              {
+                "$type": "Assignment",
+                "feature": "title",
+                "operator": "=",
+                "terminal": {
+                  "$type": "RuleCall",
+                  "rule": {
+                    "$ref": "#/rules@10"
+                  },
+                  "arguments": []
+                }
+              }
+            ],
+            "cardinality": "+"
           },
           {
-            "$type": "Assignment",
-            "feature": "accTitle",
-            "operator": "=",
-            "terminal": {
-              "$type": "RuleCall",
-              "rule": {
-                "$ref": "#/rules@8"
-              },
-              "arguments": []
-            }
-          },
-          {
-            "$type": "Assignment",
-            "feature": "title",
-            "operator": "=",
-            "terminal": {
-              "$type": "RuleCall",
-              "rule": {
-                "$ref": "#/rules@9"
-              },
-              "arguments": []
-            }
+            "$type": "RuleCall",
+            "rule": {
+              "$ref": "#/rules@11"
+            },
+            "arguments": [],
+            "cardinality": "*"
           }
-        ],
-        "cardinality": "+"
+        ]
       },
       "definesHiddenTokens": false,
       "entry": false,
       "hiddenTokens": [],
       "parameters": [],
       "wildcard": false
+    },
+    {
+      "$type": "TerminalRule",
+      "hidden": true,
+      "name": "WHITESPACE",
+      "definition": {
+        "$type": "RegexToken",
+        "regex": "[\\\\t\\\\r ]+"
+      },
+      "fragment": false
     },
     {
       "$type": "TerminalRule",
@@ -282,21 +305,7 @@ export const MermaidGrammar = (): Grammar => loadedMermaidGrammar ?? (loadedMerm
       "name": "NEWLINE",
       "definition": {
         "$type": "RegexToken",
-        "regex": "\\\\n"
-      },
-      "fragment": false,
-      "hidden": false
-    },
-    {
-      "$type": "TerminalRule",
-      "name": "NUMBER",
-      "type": {
-        "$type": "ReturnType",
-        "name": "number"
-      },
-      "definition": {
-        "$type": "RegexToken",
-        "regex": "[0-9]+(\\\\.[0-9]+)?"
+        "regex": "[\\\\n\\\\r]"
       },
       "fragment": false,
       "hidden": false
@@ -313,13 +322,17 @@ export const MermaidGrammar = (): Grammar => loadedMermaidGrammar ?? (loadedMerm
     },
     {
       "$type": "TerminalRule",
-      "hidden": true,
-      "name": "WHITESPACE",
+      "name": "NUMBER",
+      "type": {
+        "$type": "ReturnType",
+        "name": "number"
+      },
       "definition": {
         "$type": "RegexToken",
-        "regex": "[ \\\\r\\\\t]+"
+        "regex": "(0|[1-9][0-9]*)(\\\\.[1-9]+)?"
       },
-      "fragment": false
+      "fragment": false,
+      "hidden": false
     },
     {
       "$type": "TerminalRule",

--- a/packages/mermaid-parser/src/language/grammars/common.langium
+++ b/packages/mermaid-parser/src/language/grammars/common.langium
@@ -1,22 +1,22 @@
 /* fragments */
 fragment TITLE_AND_ACCESSIBILITIES:
     (accDescr=ACC_DESCR | accTitle=ACC_TITLE | title=TITLE)+
+    NEWLINE*
 ;
 
 /* terminals */
+hidden terminal WHITESPACE: /[\t\r ]+/;
+
 hidden terminal DIRECTIVE: /%%({[\w\W]*})%%\s*(?!.)/;
 hidden terminal COMMENT: /%%.*\s*/;
 hidden terminal YAML: /---\s*?[\n\r](.|\n)*---\s*(?!.)/;
 
-// placeholder terminals
 terminal ACC_DESCR: /accDescr/;
 terminal ACC_TITLE: /accTitle/;
 terminal TITLE: /title/;
 
-terminal NEWLINE: /\n/;
-terminal NUMBER returns number: /[0-9]+(\.[0-9]+)?/;
+terminal NEWLINE: /[\n\r]/;
 terminal STRING: /"[^"]*"/;
+terminal NUMBER returns number: /(0|[1-9][0-9]*)(\.[1-9]+)?/;
 
-// hidden terminals
-hidden terminal WHITESPACE: /[ \r\t]+/;
 hidden terminal WHITESPACES: /\s/;


### PR DESCRIPTION
* make `NEWLINE` rule to handle `\r`
* make `NUMBER` rule to strictly either start with one `0` or `1-9`
* reorder `WHITESPACE` rule at start
* make `TITLE_AND_ACCESSIBILITIES` could have `NEWLINE` after it